### PR TITLE
Update EdgeOS.md

### DIFF
--- a/wiki/EdgeOS.md
+++ b/wiki/EdgeOS.md
@@ -11,11 +11,18 @@ EdgeOS is a Network Operating System developed by Ubiquiti Networks. It is based
 
 ## Configuration examples
 
-The following configurations were tested on an Edgerouter X with EdgeOSv1.10.1.
-
+#### Business contract
 * Provider: Unitymedia Business
 * Gateway: Provider Fritzbox 6490 in Bridge Mode
 * IPv6 prefix: /56
+
+#### Private DualStack contract (not DS-Lite)
+* Provider: Unitymedia private contract with DualStack (not DS-Lite)
+* Gateway: Provider ConnectBox in Bridge Mode
+* IPv6 prefix: /56 (Baden-Württemberg)
+* IPv6 prefix: /59 (NRW/Hessen)
+
+The following configuration were tested on an Edgerouter X with EdgeOSv1.10.1 and on an EdgeRouter Lite with EdgeOSv2.0.6.
 
 ### IPv6 Support
 


### PR DESCRIPTION
## Description
Added IPv6 prefix information for Unitymedia DualStack private contracts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using an EdgeRouter Lite behind an ConnectBox in Bridge Mode in combination with a private DualStack contract in Hessen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it with my EdgeRouter Lite behind an ConnectBox in Bridge Mode.
I used the new placed IPv6 prefix /59 (Hessen)
Connected Devices on eth1 at the EdgeRouter Lite does got an IPv6 address.

<!--- Include details of your testing environment, and the tests you ran to -->
ConnextBox<->EdgeRouterLite<->PC
